### PR TITLE
litegapps configuration added

### DIFF
--- a/redroid.py
+++ b/redroid.py
@@ -2,6 +2,7 @@
 
 import argparse
 from stuffs.gapps import Gapps
+from stuffs.litegapps import LiteGapps
 from stuffs.magisk import Magisk
 from stuffs.ndk import Ndk
 from stuffs.widevine import Widevine
@@ -22,6 +23,10 @@ def main():
     parser.add_argument('-g', '--install-gapps',
                         dest='gapps',
                         help='Install OpenGapps to ReDroid',
+                        action='store_true')
+    parser.add_argument('-lg', '--install-litegapps',
+                        dest='litegapps',
+                        help='Install LiteGapps to ReDroid',
                         action='store_true')
     parser.add_argument('-n', '--install-ndk-translation',
                         dest='ndk',
@@ -48,6 +53,10 @@ def main():
         Gapps().install()
         dockerfile = dockerfile + "COPY gapps /\n"
         tags.append("gapps")
+    if args.litegapps:
+        LiteGapps(args.android).install()
+        dockerfile = dockerfile + "COPY litegapps /\n"
+        tags.append("litegapps")
     if args.ndk:
         if args.android in ["11.0.0", "12.0.0", "12.0.0_64only"]:
             arch = helper.host()[0]

--- a/stuffs/general.py
+++ b/stuffs/general.py
@@ -13,7 +13,7 @@ class General:
             with open(self.dl_file_name,"rb") as f:
                 bytes = f.read()
                 loc_md5 = hashlib.md5(bytes).hexdigest()
-        while not os.path.isfile(self.dl_file_name) or loc_md5 != self.act_md5:
+        while not os.path.isfile(self.dl_file_name) or (self.act_md5 != "" and loc_md5 != self.act_md5):
             if os.path.isfile(self.dl_file_name):
                 os.remove(self.dl_file_name)
                 print_color("md5 mismatches, redownloading now ....",bcolors.YELLOW)

--- a/stuffs/litegapps.py
+++ b/stuffs/litegapps.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+from stuffs.general import General
+from tools.helper import get_download_dir, host, print_color, run, bcolors
+
+class LiteGapps(General):
+    # https://master.dl.sourceforge.net/project/litegapps/litegapps/x86_64/33/lite/2024-02-24/AUTO-LiteGapps-x86_64-13.0-20240224-official.zip?viasf=1
+    dl_link_fmt = "https://master.dl.sourceforge.net/project/litegapps/litegapps/{0}/{1}/lite/2024-02-24/AUTO-LiteGapps-{0}-{2}-20240224-official.zip"
+    api_level_map = {
+        "15.0.0": "35",
+        "14.0.0": "34",
+        "13.0.0": "33",
+        "12.0.0": "31",
+        "11.0.0": "30",
+        "10.0.0": "29",
+        "9.0.0": "28",
+        "8.1.0": "27",
+        "8.0.0": "26",
+        "7.1.2": "25",
+        "7.1.1": "25",
+        "7.1.0": "25",
+        "7.0.0": "24",
+    }
+    arch = host()
+    download_loc = get_download_dir()
+    dl_file_name = os.path.join(download_loc, "litegapps.zip")
+    act_md5 = ""
+    copy_dir = "./litegapps"
+    extract_to = "/tmp/litegapps/extract"
+
+    def __init__(self, version):
+        self.version = version
+        self.dl_link = self.dl_link_fmt.format(self.arch[0], self.api_level_map[self.version], '.'.join(self.version.split('.')[:2]))
+
+    def download(self):
+        print_color("Downloading LiteGapps now .....", bcolors.GREEN)
+        super().download()
+    
+    def copy(self):
+        if os.path.exists(self.copy_dir):
+            shutil.rmtree(self.copy_dir)
+        if not os.path.exists(self.extract_to):
+            os.makedirs(self.extract_to)
+        if not os.path.exists(os.path.join(self.extract_to, "appunpack")):
+            os.makedirs(os.path.join(self.extract_to, "appunpack"))
+
+        # extract extract_to/files/files.tar.xz file to extract_to/appunpack
+        run(["tar", "-xvf", os.path.join(self.extract_to, "files", "files.tar.xz"), "-C", os.path.join(self.extract_to, "appunpack")])
+        shutil.copytree(os.path.join(self.extract_to, "appunpack", self.arch[0], self.api_level_map[self.version], "system"), os.path.join(self.copy_dir, "system"), dirs_exist_ok=True)


### PR DESCRIPTION
Configuration for building the image with LiteGapps added since I think OpenGapps is not working with android 12+ (or maybe I couldn't make it work)

2 things to add to the PR before merging
- LiteGapps doesn't provide MD5's of the files, so I had to change the `stuffs/general.py` file a bit to accept empty md5's. If anyone know any other way, happy to help.
- I haven't added anything to README.md about this, probably we should add this too.