### PR TITLE
chore: bump ndk to 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ ro.product.cpu.abilist=x86_64,arm64-v8a,x86,armeabi-v7a,armeabi \
     ro.dalvik.vm.isa.arm=x86 \
     ro.dalvik.vm.isa.arm64=x86_64 \
     ro.enable.native.bridge.exec=1 \
+    ro.vendor.enable.native.bridge.exec=1 \
+    ro.vendor.enable.native.bridge.exec64=1 \
     ro.dalvik.vm.native.bridge=libndk_translation.so \
-    ro.ndk_translation.version=0.2.2 \
+    ro.ndk_translation.version=0.2.3 \
 ```
 
 If you need to use libndk on `redroid:12.0.0_64only` image, you should start the container with the following command

--- a/stuff/ndk.py
+++ b/stuff/ndk.py
@@ -6,10 +6,10 @@ from tools.helper import bcolors, get_download_dir, print_color, run
 class Ndk(General):
     download_loc = get_download_dir()
     copy_dir = "./ndk"
-    dl_link = "https://github.com/supremegamers/vendor_google_proprietary_ndk_translation-prebuilt/archive/0c6b0aad45498bbdb22eb1311b145d08ff4ce1fc.zip"
+    dl_link = "https://github.com/supremegamers/vendor_google_proprietary_ndk_translation-prebuilt/archive/9324a8914b649b885dad6f2bfd14a67e5d1520bf.zip"
     dl_file_name = os.path.join(download_loc, "libndktranslation.zip")
     extract_to = "/tmp/libndkunpack"
-    act_md5 = "6d4b3788ac9e7e953aada561f64a2563"
+    act_md5 = "c9572672d1045594448068079b34c350"
 #     init_rc_component = """
 # # Enable native bridge for target executables
 # on early-init
@@ -32,7 +32,7 @@ class Ndk(General):
         run(["chmod", "+x", self.extract_to, "-R"])
     
         print_color("Copying libndk library files ...", bcolors.GREEN)
-        shutil.copytree(os.path.join(self.extract_to, "vendor_google_proprietary_ndk_translation-prebuilt-0c6b0aad45498bbdb22eb1311b145d08ff4ce1fc", "prebuilts"), os.path.join(self.copy_dir, "system"), dirs_exist_ok=True)
+        shutil.copytree(os.path.join(self.extract_to, "vendor_google_proprietary_ndk_translation-prebuilt-9324a8914b649b885dad6f2bfd14a67e5d1520bf", "prebuilts"), os.path.join(self.copy_dir, "system"), dirs_exist_ok=True)
 
         init_path = os.path.join(self.copy_dir, "system", "etc", "init", "ndk_translation.rc")
         os.chmod(init_path, 0o644)


### PR DESCRIPTION
Sync libndk version from https://github.com/casualsnek/waydroid_script/tree/main

Btw I found some apps crashes very often, but after putting these lines into run args, apps won't crash any more!

It worked like a charm, so I also added these args to readme.

```text
    ro.vendor.enable.native.bridge.exec=1 \
    ro.vendor.enable.native.bridge.exec64=1 \
```