### PR TITLE
fixed issue with litegapps 64 only 12.00

### DIFF
--- a/stuff/litegapps.py
+++ b/stuff/litegapps.py
@@ -212,4 +212,5 @@ class LiteGapps(General):
 
         # extract extract_to/files/files.tar.xz file to extract_to/appunpack
         run( [ "tar", "-xvf", os.path.join(self.extract_to, "files", "files.tar.xz"), "-C", os.path.join(self.extract_to, "appunpack"), ])
-        shutil.copytree( os.path.join( self.extract_to, "appunpack", self.arch[0], self.api_level_map[self.version], "system",), os.path.join(self.copy_dir, "system"), dirs_exist_ok=True,)
+        base_version = self.version.replace("_64only", "").replace("__64only", "")
+        shutil.copytree( os.path.join( self.extract_to, "appunpack", self.arch[0], self.api_level_map[base_version], "system",), os.path.join(self.copy_dir, "system"), dirs_exist_ok=True,)


### PR DESCRIPTION
when trying to install litegapps 12 64 only, it would fail in the current script.

fix:         
```
base_version = self.version.replace("_64only", "").replace("__64only", "")
        shutil.copytree( os.path.join( self.extract_to, "appunpack", self.arch[0], self.api_level_map[base_version], "system",), os.path.join(self.copy_dir, "system"), dirs_exist_ok=True,)
```
corrected naming