### PR TITLE
Update redroid.py

### DIFF
--- a/redroid.py
+++ b/redroid.py
@@ -73,7 +73,7 @@ def main():
         tags.append("litegapps")
     if args.mindthegapps:
         MindTheGapps(args.android).install()
-        dockerfile = dockerfile + "COPY mindthegapps /\n"
+        dockerfile = dockerfile + "COPY mindthegapps /\nENTRYPOINT [\"/init\", \"androidboot.hardware=redroid\", \"ro.setupwizard.mode=DISABLED\"]\n"
         tags.append("mindthegapps")
     if args.ndk:
         if args.android in ["11.0.0", "12.0.0", "12.0.0_64only"]:


### PR DESCRIPTION
Work around blank screen with MindTheGapps

I thought this was fixing #17, but I realize that user was reporting the issues for OpenGapps, as opposed to MindTheGapps. I suspect we would be better served by adding this Entrypoint for any of the Gapps options, but this approach at least fixed things for me. 